### PR TITLE
Update composer.json to include PHP 8 for compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }
   ],
   "require": {
-    "php": "^7.2",
+    "php": "^7.2|^8.0",
     "psr/http-message": "^1.0",
     "psr/cache": "^1.0",
     "php-http/httplug": "^1.1 || ^2.0",


### PR DESCRIPTION
This ensures newer versions of PHP can still use this package. I'm using it in my Laravel application with PHP 8.0.5 and everything works fine