### PR TITLE
Fix MalformedUriException error

### DIFF
--- a/src/Api/Assignments.php
+++ b/src/Api/Assignments.php
@@ -11,7 +11,7 @@ final class Assignments extends AbstractApi
 {
     public function getByStartAndEndDate(DateTimeInterface $startDate, DateTimeInterface $endDate)
     {
-        return $this->get('assignments', [
+        return $this->get('/assignments', [
             'start_date' => $startDate->format(Client::DATE_FORMAT),
             'end_date' => $endDate->format(Client::DATE_FORMAT),
         ]);

--- a/src/Api/Billing.php
+++ b/src/Api/Billing.php
@@ -13,6 +13,6 @@ final class Billing extends AbstractApi
      */
     public function getSubscription()
     {
-        return $this->get('billing/subscription');
+        return $this->get('/billing/subscription');
     }
 }

--- a/src/Api/Clients.php
+++ b/src/Api/Clients.php
@@ -8,6 +8,6 @@ final class Clients extends AbstractApi
 {
     public function getAll()
     {
-        return $this->get('clients');
+        return $this->get('/clients');
     }
 }

--- a/src/Api/Milestones.php
+++ b/src/Api/Milestones.php
@@ -11,7 +11,7 @@ final class Milestones extends AbstractApi
 {
     public function getByStartAndEndDate(DateTimeInterface $startDate, DateTimeInterface $endDate)
     {
-        return $this->get('milestones', [
+        return $this->get('/milestones', [
             'start_date' => $startDate->format(Client::DATE_FORMAT),
             'end_date' => $endDate->format(Client::DATE_FORMAT),
         ]);

--- a/src/Api/People.php
+++ b/src/Api/People.php
@@ -8,13 +8,13 @@ final class People extends AbstractApi
 {
     public function getAll()
     {
-        return $this->get('people');
+        return $this->get('/people');
     }
 
     public function getById(int $id)
     {
         return $this->get(
-            sprintf('people/%d', $id)
+            sprintf('/people/%d', $id)
         );
     }
 }

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -8,6 +8,6 @@ final class Projects extends AbstractApi
 {
     public function getAll()
     {
-        return $this->get('projects');
+        return $this->get('/projects');
     }
 }

--- a/src/Api/User.php
+++ b/src/Api/User.php
@@ -8,21 +8,21 @@ final class User extends AbstractApi
 {
     public function whoAmI()
     {
-        return $this->get('whoami');
+        return $this->get('/whoami');
     }
 
     public function getConnections()
     {
-        return $this->get('user_connections');
+        return $this->get('/user_connections');
     }
 
     public function getRoles()
     {
-        return $this->get('roles');
+        return $this->get('/roles');
     }
 
     public function getFtuxState()
     {
-        return $this->get('ftux_state');
+        return $this->get('/ftux_state');
     }
 }


### PR DESCRIPTION
Resolves the error: 
```
[2022-06-09 19:21:39] local.ERROR: The path of a URI with an authority must start with a slash "/" or be empty {"userId":1,"exception":"[object] (GuzzleHttp\\Psr7\\Exception\\MalformedUriException(code: 0): The path of a URI with an authority must start with a slash \"/\" or be empty at /var/www/html/vendor/guzzlehttp/psr7/src/Uri.php:735)
```

This was occurring when using the package with `laravel/framework:^9.11` and `php-http/guzzle7-adapter:^1.0`

**Warning: testing has not been done outside of this environment so may break in older PHP versions**